### PR TITLE
Clear ModalQueue if it's not enabled

### DIFF
--- a/Pod/Classes/UIViewController+LVModalQueue.m
+++ b/Pod/Classes/UIViewController+LVModalQueue.m
@@ -287,6 +287,11 @@ static BOOL isTransitioning = NO;
 + (void)setEnabled:(BOOL)enabled
 {
     _LVModalQueueEnabled = enabled;
+
+    if (!enabled) {
+        isTransitioning = NO;
+        transitionQueue = [NSMutableArray array];
+    }
 }
 
 + (BOOL)isEnabled


### PR DESCRIPTION
Clearing the transitionQueue if _LVModalQueueEnabled is set to false.
